### PR TITLE
[#48] Add test for reading multiple channels - faulty definition case

### DIFF
--- a/core/src/test/java/org/wildfly/channel/mapping/ChannelTestCase.java
+++ b/core/src/test/java/org/wildfly/channel/mapping/ChannelTestCase.java
@@ -72,6 +72,23 @@ public class ChannelTestCase {
         }
     }
 
+    @Test()
+    public void faultyMultipleChannelsTest() throws IOException {
+        ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+        URL file = tccl.getResource("channels/faulty-multiple-channels.yaml");
+
+        try (InputStream in = file.openStream()) {
+            ChannelMapper.from(file);
+            byte[] bytes = in.readAllBytes();
+            String content = new String(bytes, Charset.defaultCharset());
+            // one channel definition out of multiple is faulty
+            // - we expect loading channels to raise exception, no channel to be loaded
+            Assertions.assertThrows(RuntimeException.class, () -> {
+                ChannelMapper.fromString(content);
+            });
+        }
+    }
+
     @Test
     public void simpleChannelTest() throws MalformedURLException {
         ClassLoader tccl = Thread.currentThread().getContextClassLoader();

--- a/core/src/test/resources/channels/faulty-multiple-channels.yaml
+++ b/core/src/test/resources/channels/faulty-multiple-channels.yaml
@@ -1,0 +1,6 @@
+---
+name: Channel for WildFly 27
+---
+name: Channel for WildFly 28
+---
+this third channel is misconfigured


### PR DESCRIPTION
Add testcase for faulty multiple channels test.
We want to codify behaviour of what will happen if one channel is faulty.